### PR TITLE
Updated IOCextractor to leverage python-cybox v2.0.1.0

### DIFF
--- a/IOCextractor.py
+++ b/IOCextractor.py
@@ -11,6 +11,7 @@ import sys
 
 from Tkinter import *
 from tkFileDialog import askopenfilename, asksaveasfilename, askdirectory
+from distutils.version import LooseVersion
 
 try:
     import cybox
@@ -20,20 +21,10 @@ try:
     import cybox.utils
     
     if hasattr(cybox, "__version__"):
-        version = cybox.__version__
-        pattern = r"(\d)\.(\d)\.(\d+)([a-z]\d+)?\.?(\d+)?"
-        m = re.search(pattern, version)
-        
-        major   = int(m.group(1)) if m.group(1) else 0
-        minor   = int(m.group(2)) if m.group(2) else 0
-        update  = int(m.group(3)) if m.group(3) else 0
-        build   = int(m.group(5)) if m.group(5) else 0    
-        
-        minver = (2,0,1,0) # minimum python-cybox version is v2.0.1.0
-        if ((major, minor, update, build) >= minver):
+        if (LooseVersion(cybox.__version__) >= LooseVersion('2.0.1.0')):
             python_cybox_available = True
         else:
-            raise ImportError("python-cybox must be v2.0.1.0 or greater. Found v%s" % version)
+            raise ImportError("python-cybox must be v2.0.1.0 or greater. Found v%s" % cybox.__version__)
     else:
         raise ImportError("python-cybox must be v2.0.1.0 or greater")
     

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Compatibility and Requirements
 * Compatible and tested operating systems: Windows 7, Mac OS 10.8.4, Ubuntu 13.04
 * IOCextractor requires TkInter (http://wiki.python.org/moin/TkInter). 
 * OpenIOC exporting requires the ioc_writer library (https://github.com/mandiant/ioc_writer).
-* CybOX exporting requires python-cybox 2.0.x (https://pypi.python.org/pypi/cybox/)
+* CybOX exporting requires python-cybox >= 2.0.1.0 (https://pypi.python.org/pypi/cybox/)
 
 The program is written in Python 2.7, and a binary version for Windows is provided (IOCextractor.zip). 
 


### PR DESCRIPTION
I updated IOCextractor to optionally export CybOX v2.0.1 content. To do this, I changed the following:
- Look for python-cybox v2.0.1.0 or greater
- Updated domain name  export to use `cybox.helper.create_domain_name_observable(...)`
- Updated namespace export code to align with updates to python-cybox
- Updated README.md

Thanks!
Bryan Worrell
