### PR TITLE
update ioc_api.make_indicatoritem_node call to match the case of the …

### DIFF
--- a/IOCextractor.py
+++ b/IOCextractor.py
@@ -330,7 +330,7 @@ def export_openioc():
         search = 'Network/URI'
         content_type = 'string'
         content = uri
-        IndicatorItem_node = ioc_api.make_IndicatorItem_node(condition, document, search, content_type, content, negate=negate, preserve_case=preserve_case, context_type = None)
+        IndicatorItem_node = ioc_api.make_indicatoritem_node(condition, document, search, content_type, content, negate=negate, preserve_case=preserve_case, context_type = None)
         return IndicatorItem_node
     
     def make_email_from(from_address, condition='contains', negate=False, preserve_case = False):
@@ -338,7 +338,7 @@ def export_openioc():
         search = 'Email/From'
         content_type = 'string'
         content = from_address
-        IndicatorItem_node = ioc_api.make_IndicatorItem_node(condition, document, search, content_type, content, negate=negate, preserve_case=preserve_case, context_type = None)
+        IndicatorItem_node = ioc_api.make_indicatoritem_node(condition, document, search, content_type, content, negate=negate, preserve_case=preserve_case, context_type = None)
         return IndicatorItem_node
 
     output_directory = askdirectory(title = "Save IOC To")


### PR DESCRIPTION
…function

I was receiving the following error:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/lib-tk/Tkinter.py", line 1536, in __call__
    return self.func(*args)
  File "IOCextractor.py", line 382, in export_openioc
    indicator_node = make_email_from(value)
  File "IOCextractor.py", line 341, in make_email_from
    IndicatorItem_node = ioc_api.make_IndicatorItem_node(condition, document, search, content_type, content, negate=negate, preserve_case=preserve_case, context_type = None)
AttributeError: 'module' object has no attribute 'make_IndicatorItem_node'
```

After some digging it looks like ioc_writer updated the function name, note that it's all lower case now:

```
def make_indicatoritem_node(condition,
                            document,
                            search,
                            content_type,
                            content,
                            preserve_case=False,
                            negate=False,
                            context_type='mir',
                            nid=None):
```

Quick fix - it can now successfully output the IOC file.
